### PR TITLE
minor update holo.py

### DIFF
--- a/pyopia/instrument/holo.py
+++ b/pyopia/instrument/holo.py
@@ -221,7 +221,7 @@ def create_kernel(im, pixel_size, wavelength, n, offset, minZ, maxZ, stepZ):
 
     f = (np.pi / (pixel_size / 1e6)) * (f1**2 + f2**2)**0.5
 
-    z = (np.arange(minZ * 1e-3, maxZ * 1e-3, stepZ * 1e-3) / n) + (offset * 1e-3)
+    z = (np.linspace(minZ * 1e-3, maxZ * 1e-3, np.int32(maxZ/stepZ + 1)) / n) + (offset * 1e-3)
 
     wavelength_m = wavelength * 1e-9
     k = 2 * np.pi / wavelength_m


### PR DESCRIPTION
For example, we have a detection depth that ranges from 0-50 mm, the "np.arange" creates an array of [0, 1, 2, ..., 49] but the "np.linspace" creates the array of [0, 1, 2, ... 50].

--
trying to create a pull request; plz feel free to reject it

Thanks
YXS