### PR TITLE
pyopia-gui-support: staging branch (not for merging as one PR)

### DIFF
--- a/PYOPIA_GUI_SUPPORT.md
+++ b/PYOPIA_GUI_SUPPORT.md
@@ -10,5 +10,6 @@ this branch is deleted once they have.
 
 Docker images built from this branch use distinct tags, never `latest`.
 
-Scope: #434 (holo only - uvp split to #436), #427, #423, #426, plus a
-make-montage-scaled CLI command (follow-on to #407, no separate issue)
+Scope: #434 (holo only - uvp split to #436), #427, #423, #426, #421 (code
+ready, blocked on a "sample-data" GitHub release being created - see #421),
+plus a make-montage-scaled CLI command (follow-on to #407, no separate issue)

--- a/PYOPIA_GUI_SUPPORT.md
+++ b/PYOPIA_GUI_SUPPORT.md
@@ -10,6 +10,6 @@ this branch is deleted once they have.
 
 Docker images built from this branch use distinct tags, never `latest`.
 
-Scope: #434 (holo only - uvp split to #436), #427, #423, #426, #421 (code
-ready, blocked on a "sample-data" GitHub release being created - see #421),
-plus a make-montage-scaled CLI command (follow-on to #407, no separate issue)
+Scope: #434 (holo only - uvp split to #436), #427, #423, #426, #421 (points at
+the "sample-data_v2.0.0" release, published - see #421), plus a
+make-montage-scaled CLI command (follow-on to #407, no separate issue)

--- a/PYOPIA_GUI_SUPPORT.md
+++ b/PYOPIA_GUI_SUPPORT.md
@@ -1,0 +1,12 @@
+# pyopia-gui-support
+
+Staging branch for fixes needed by
+[pyopia-gui](https://github.com/nimmo-smith-technologies/pyopia-gui), rebased
+against `main` regularly.
+
+Not a release channel. Each fix lands in `main` via its own PR (`Closes #N`);
+this branch is deleted once they have.
+
+Docker images built from this branch use distinct tags, never `latest`.
+
+Scope: #434, #427, #423, #426

--- a/PYOPIA_GUI_SUPPORT.md
+++ b/PYOPIA_GUI_SUPPORT.md
@@ -2,7 +2,8 @@
 
 Staging branch for fixes needed by
 [pyopia-gui](https://github.com/nimmo-smith-technologies/pyopia-gui), rebased
-against `main` regularly.
+regularly against `summer26-features` (currently its furthest-along, not yet
+merged, upstream base - see #430/#431), or `main` once that work has landed.
 
 Not a release channel. Each fix lands in `main` via its own PR (`Closes #N`);
 this branch is deleted once they have.

--- a/PYOPIA_GUI_SUPPORT.md
+++ b/PYOPIA_GUI_SUPPORT.md
@@ -10,4 +10,5 @@ this branch is deleted once they have.
 
 Docker images built from this branch use distinct tags, never `latest`.
 
-Scope: #434, #427, #423, #426
+Scope: #434 (holo only - uvp split to #436), #427, #423, #426, plus a
+make-montage-scaled CLI command (follow-on to #407, no separate issue)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ docker run --rm \
 
 Any PyOPIA CLI command works, e.g. `docker run --rm ghcr.io/sintef/pyopia:latest --help`.
 
+### Windows (PowerShell)
+
+The invocations above use POSIX/bash syntax. In PowerShell, drop `--user $(id -u):$(id -g)`
+(Docker Desktop on Windows doesn't use the same UID/GID bind-mount permission model
+Linux does, so it isn't needed) and use `${PWD}` in place of `$PWD`:
+
+```powershell
+docker run --rm `
+    -v "${PWD}:${PWD}" -w "${PWD}" `
+    ghcr.io/sintef/pyopia:latest `
+    process config.toml
+```
+
 ## Using docker compose
 
 Each GitHub release attaches a `compose.yaml` as an asset. 

--- a/pyopia/cli.py
+++ b/pyopia/cli.py
@@ -137,13 +137,13 @@ def generate_config(
     instrument : str
         either `silcam`, `holo` or `uvp`
     raw_files : str
-        raw_files
+        Glob pattern matching the raw image files to process, e.g. `images/*.silc`
     model_path : str
-        model_path
+        Path to the classifier model file used by the classification step
     outfolder : str
-        outfolder
+        Directory the processed output (STATS files, ROI images) is written to
     output_prefix : str
-        output_prefix
+        Filename prefix used for output files, e.g. `<output_prefix>-STATS.nc`
     """
     match instrument:
         case "silcam":
@@ -228,7 +228,7 @@ def init_project(
     print(f"[blue]Creating PyOPIA project folder {proj_folder}")
     if proj_folder.exists():
         print(f"[red]ERROR: Project folder {proj_folder} exists")
-        return
+        raise typer.Exit(code=1)
     proj_folder.mkdir()
 
     # Create subfolders
@@ -286,7 +286,12 @@ def init_project(
 
 
 @app.command()
-def process(config_filename: str, num_chunks: int = 1, strategy: str = "block"):
+def process(
+    config_filename: str,
+    num_chunks: int = 1,
+    strategy: str = "block",
+    progress_file: str = None,
+):
     """Run a PyOPIA processing pipeline based on given a config.toml
 
     Parameters
@@ -294,11 +299,20 @@ def process(config_filename: str, num_chunks: int = 1, strategy: str = "block"):
     config_filename : str
         Config filename
 
-    numchunks : int, optional
-        Split the dataset into chucks, and process in parallell, by default 1
+    num_chunks : int, optional
+        Split the dataset into chunks, and process in parallel, by default 1
 
     strategy : str, optional
-        Strategy to use for chunking dataset, either `block` or `interleave`. Defult: `block`
+        Strategy to use for chunking dataset, either `block` or `interleave`. Default: `block`
+
+    progress_file : str, optional
+        If given, periodically write `{"processed": N, "total": M}` as JSON to this
+        path after each image, for external tooling to poll (e.g. a GUI driving this
+        command as a subprocess) rather than parsing log output. Written
+        write-temp-then-rename so a concurrent reader never sees a partial write. With
+        `num_chunks > 1`, each chunk writes its own `<progress_file>.chunk<N>` instead
+        of one shared file, since multiple processes writing the same path at once
+        would race.
     """
     t1 = time.time()
 
@@ -309,53 +323,54 @@ def process(config_filename: str, num_chunks: int = 1, strategy: str = "block"):
     logger = logging.getLogger("rich")
 
     try:
-        with Progress(transient=True) as progress:
-            progress.console.print(f"[blue]PYOPIA VERSION {pyopia.__version__}")
-            progress.console.print("[blue]LOAD CONFIG")
-            logger.info(f"PyOPIA process started {pd.Timestamp.now()}")
+        logger.info(f"PYOPIA VERSION {pyopia.__version__}")
+        logger.info("LOAD CONFIG")
+        logger.info(f"PyOPIA process started {pd.Timestamp.now()}")
 
-            check_chunks(num_chunks, pipeline_config)
+        check_chunks(num_chunks, pipeline_config)
 
-            progress.console.print("[blue]OBTAIN IMAGE LIST")
-            conf_corrbg = pipeline_config["steps"].get("correctbackground", dict())
-            average_window = conf_corrbg.get("average_window", 0)
-            bgshift_function = conf_corrbg.get("bgshift_function", "pass")
-            raw_files = pyopia.pipeline.FilesToProcess(
-                pipeline_config["general"]["raw_files"]
+        logger.info("OBTAIN IMAGE LIST")
+        conf_corrbg = pipeline_config["steps"].get("correctbackground", dict())
+        average_window = conf_corrbg.get("average_window", 0)
+        bgshift_function = conf_corrbg.get("bgshift_function", "pass")
+        raw_files = pyopia.pipeline.FilesToProcess(
+            pipeline_config["general"]["raw_files"]
+        )
+        raw_files.prepare_chunking(
+            num_chunks, average_window, bgshift_function, strategy=strategy
+        )
+
+        # Write the dataset list of images to a text file
+        raw_files.to_filelist_file("filelist.txt")
+
+        logger.info("PREPARE FOLDERS")
+        if "output" not in pipeline_config["steps"]:
+            raise Exception(
+                'The given config file is missing an "output" step.\n'
+                + "This is needed to setup how to save data to disc."
             )
-            raw_files.prepare_chunking(
-                num_chunks, average_window, bgshift_function, strategy=strategy
-            )
+        output_datafile = pipeline_config["steps"]["output"]["output_datafile"]
+        os.makedirs(os.path.split(output_datafile)[:-1][0], exist_ok=True)
 
-            # Write the dataset list of images to a text file
-            raw_files.to_filelist_file("filelist.txt")
+        if os.path.isfile(output_datafile + "-STATS.nc"):
+            dt_now = datetime.datetime.now().strftime("D%Y%m%dT%H%M%S")
+            newname = output_datafile + "-conflict-" + str(dt_now) + "-STATS.nc"
+            logger.warning(f"Renaming conflicting file to: {newname}")
+            os.rename(output_datafile + "-STATS.nc", newname)
 
-            progress.console.print("[blue]PREPARE FOLDERS")
-            if "output" not in pipeline_config["steps"]:
-                raise Exception(
-                    'The given config file is missing an "output" step.\n'
-                    + "This is needed to setup how to save data to disc."
-                )
-            output_datafile = pipeline_config["steps"]["output"]["output_datafile"]
-            os.makedirs(os.path.split(output_datafile)[:-1][0], exist_ok=True)
-
-            if os.path.isfile(output_datafile + "-STATS.nc"):
-                dt_now = datetime.datetime.now().strftime("D%Y%m%dT%H%M%S")
-                newname = output_datafile + "-conflict-" + str(dt_now) + "-STATS.nc"
-                logger.warning(f"Renaming conflicting file to: {newname}")
-                os.rename(output_datafile + "-STATS.nc", newname)
-
-            progress.console.print("[blue]INITIALISE PIPELINE")
+        logger.info("INITIALISE PIPELINE")
 
         # With one chunk we keep the non-multiprocess functionality to ensure backwards compatibility
         job_list = []
         if num_chunks == 1:
-            process_file_list(raw_files, pipeline_config, 0, log_queue)
+            process_file_list(raw_files, pipeline_config, 0, log_queue, progress_file=progress_file)
         else:
             for c, chunk in enumerate(raw_files.chunked_files):
+                chunk_progress_file = f"{progress_file}.chunk{c}" if progress_file else None
                 job = multiprocessing.Process(
                     target=process_file_list,
                     args=(chunk, pipeline_config, c, log_queue),
+                    kwargs={"progress_file": chunk_progress_file},
                     name=f"chunk-{c}",
                 )
                 job_list.append(job)
@@ -365,13 +380,12 @@ def process(config_filename: str, num_chunks: int = 1, strategy: str = "block"):
 
         # If we are using multiprocessing, make sure all jobs have finished
         [job.join() for job in job_list]
+
+        # Calculate and log total processing time, before the queue listener stops
+        time_total = pd.to_timedelta(time.time() - t1, "seconds")
+        logger.info(f"PROCESSING COMPLETED IN {time_total}")
     finally:
         stop_queue_logging(listener, log_queue)
-
-    # Calculate and print total processing time
-    time_total = pd.to_timedelta(time.time() - t1, "seconds")
-    with Progress(transient=True) as progress:
-        progress.console.print(f"[blue]PROCESSING COMPLETED IN {time_total}")
 
 
 @app.command()
@@ -596,7 +610,19 @@ def export_to_ecotaxa(
     )
 
 
-def process_file_list(file_list, pipeline_config, c, log_queue):
+def _write_progress_file(progress_file, processed, total):
+    """Atomically write `{"processed": N, "total": M}` as JSON to `progress_file`.
+
+    Write-temp-then-rename so a concurrent reader (e.g. a GUI polling this file) never
+    sees a partial write.
+    """
+    tmp_path = f"{progress_file}.tmp"
+    with open(tmp_path, "w") as fh:
+        json.dump({"processed": processed, "total": total}, fh)
+    os.replace(tmp_path, progress_file)
+
+
+def process_file_list(file_list, pipeline_config, c, log_queue, progress_file=None):
     """Run a PyOPIA processing pipeline for a chuncked list of files based on a given config.toml
 
     Parameters
@@ -615,16 +641,23 @@ def process_file_list(file_list, pipeline_config, c, log_queue):
         Queue set up by `setup_queue_log_listener` in the calling command. Logging is
         routed through it rather than this process opening its own handlers, so that
         multiple chunks running in parallel don't write to the same log file at once.
+
+    progress_file : str, optional
+        If given, write `{"processed": N, "total": M}` as JSON to this path after each
+        file in `file_list` (see `process`'s own `progress_file` docs for the
+        multi-chunk naming convention).
     """
     processing_pipeline = pyopia.pipeline.Pipeline(pipeline_config)
     route_logging_through_queue(pipeline_config, log_queue)
     logger = logging.getLogger("rich")
 
+    total = len(file_list)
     with get_custom_progress_bar(
         f"[blue]Processing progress (chunk {c})", disable=c != 0
     ) as pbar:
-        for filename in pbar.track(
-            file_list, description=f"[blue]Processing progress (chunk {c})"
+        for processed, filename in enumerate(
+            pbar.track(file_list, description=f"[blue]Processing progress (chunk {c})"),
+            start=1,
         ):
             try:
                 logger.debug(f"Chunk {c} starting to process {filename}")
@@ -646,6 +679,9 @@ def process_file_list(file_list, pipeline_config, c, log_queue):
                 )
                 logger.error(f"{type(e).__name__}: {e}")
                 logger.error("".join(traceback.format_tb(e.__traceback__)))
+            finally:
+                if progress_file is not None:
+                    _write_progress_file(progress_file, processed, total)
 
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(processName)s [%(module)s.%(funcName)s] %(message)s"

--- a/pyopia/cli.py
+++ b/pyopia/cli.py
@@ -568,6 +568,44 @@ def make_montage(
 
 
 @app.command()
+def summary_stats(stats_filename: pathlib.Path, json_output: bool = False):
+    """Print summary statistics (particle count, d50, size distribution) from a STATS file
+
+    Parameters
+    ----------
+    stats_filename : pathlib.Path
+        Path to a `-STATS.nc` file, as produced by `process` or `merge-mfdata`
+    json_output : bool, optional
+        Print machine-readable JSON to stdout instead of a human-readable summary,
+        by default False
+    """
+    xstats = pyopia.io.load_stats(str(stats_filename))
+    config = pyopia.io.steps_from_xstats(xstats)
+    pixel_size = config["general"]["pixel_size"]
+    stats = xstats.to_pandas()
+
+    dias, number_distribution = pyopia.statistics.nd_from_stats(stats, pixel_size)
+    d50 = pyopia.statistics.d50_from_stats(stats, pixel_size)
+
+    result = {
+        "particle_count": len(stats),
+        "images_with_particles": pyopia.statistics.count_images_in_stats(stats),
+        "d50_microns": float(d50),
+        "dias": dias.tolist(),
+        "number_distribution": number_distribution.tolist(),
+    }
+
+    if json_output:
+        # Not using this module's `print` (from rich import print, above) - it interprets
+        # "[...]" as console markup, which would corrupt the JSON array fields below.
+        sys.stdout.write(json.dumps(result) + "\n")
+    else:
+        print(f"[blue]Particle count: {result['particle_count']}")
+        print(f"[blue]Images with particles: {result['images_with_particles']}")
+        print(f"[blue]d50: {result['d50_microns']:.1f} um")
+
+
+@app.command()
 def export_to_ecotaxa(
     stats_filename: pathlib.Path,
     export_filename: pathlib.Path,

--- a/pyopia/cli.py
+++ b/pyopia/cli.py
@@ -177,9 +177,15 @@ def init_project(
     instrument : str
         Either `silcam`, `holo` or `uvp`
     example_data: bool
-        If specified, download 10 example SilCam images and put them in the images/ folder
+        If specified, download real example images matching `instrument` into the
+        images/ folder: 10 SilCam images for `silcam`, a folder of holograms for
+        `holo`. Not yet supported for `uvp` - falls back to no example data.
     """
-    raw_files = "images/*.silc"
+    raw_files_patterns = {
+        "silcam": "images/*.silc",
+        "holo": "images/holo_test_data_01/*.pgm",
+    }
+    raw_files = raw_files_patterns.get(instrument, "images/*.silc")
     outfolder = "processed"
     output_prefix = project_name
     model_path = ""
@@ -197,7 +203,6 @@ def init_project(
         title = "PyOPIA example data"
         longitude = 14.45498
         latitude = 68.89363
-        instrument = "silcam"
 
     # @todo Move this to instrument modules
     seavox_instrument_identifier = (
@@ -274,7 +279,11 @@ def init_project(
         fh.write(pyopia.auxillarydata.AUXILLARY_DATA_FILE_TEMPLATE)
 
     # Get example image data
-    if example_data:
+    if example_data and instrument == "holo":
+        print("[blue]Downloading example holo images")
+        with contextlib.chdir(images_folder):
+            pyopia.exampledata.get_folder_from_holo_repository(existsok=True)
+    elif example_data:
         print("[blue]Downloading example SilCam images")
         example_imgs_zip = proj_folder / Path("pyopia-example-images-10.zip")
         pyopia.exampledata.get_file_from_pysilcam_blob(

--- a/pyopia/cli.py
+++ b/pyopia/cli.py
@@ -568,6 +568,49 @@ def make_montage(
 
 
 @app.command()
+def make_montage_scaled(
+    stats_filename: pathlib.Path,
+    output_filename: str = "montage.png",
+    rel_scale: float = 1.0,
+):
+    """Create a scaled circular montage of particles, packed largest first
+
+    Unlike `make-montage`, every particle is attempted (no upfront subsampling), and
+    `rel_scale` controls how much of the canvas is available for packing - set it
+    proportional to relative sample size when comparing several montages side by side,
+    so packed density stays a fair comparison rather than every montage looking
+    equally full regardless of how much data it represents. See
+    `pyopia.statistics.make_montage_scaled`'s own docstring for the full explanation.
+
+    Parameters
+    ----------
+    stats_filename : pathlib.Path
+        Path to a `-STATS.nc` file, as produced by `process` or `merge-mfdata`
+    output_filename : str
+        Store montage figure to this filename
+    rel_scale : float, optional
+        Fraction (0-1) of the full canvas area used as the circular placement
+        boundary, by default 1.0
+    """
+    print("[blue]LOAD STATS")
+    xstats = pyopia.io.load_stats(str(stats_filename))
+    config = pyopia.io.steps_from_xstats(xstats)
+
+    print("[blue]CREATING MONTAGE")
+    montage = pyopia.statistics.make_montage_scaled(
+        xstats.to_pandas(),
+        config["general"]["pixel_size"],
+        config["steps"]["statextract"]["export_outputpath"],
+        rel_scale=rel_scale,
+        eyecandy=False,
+    )
+
+    print("[blue]STORING MONTAGE")
+    pyopia.plotting.montage_plot(montage, config["general"]["pixel_size"])
+    plt.savefig(output_filename, dpi=300, bbox_inches="tight")
+
+
+@app.command()
 def summary_stats(stats_filename: pathlib.Path, json_output: bool = False):
     """Print summary statistics (particle count, d50, size distribution) from a STATS file
 

--- a/pyopia/exampledata.py
+++ b/pyopia/exampledata.py
@@ -169,13 +169,13 @@ def get_example_hologram_and_background(download_directory="./"):
 
 
 def get_folder_from_holo_repository(foldername="holo_test_data_01", existsok=False):
-    """Downloads and unzips a folder of holo test images from the "sample-data" GitHub
-    release into the working dir, if it doesn't already exist.
+    """Downloads and unzips a folder of holo test images from the "sample-data_v2.0.0"
+    GitHub release into the working dir, if it doesn't already exist.
 
     Only works for folder names that have actually been uploaded as a
     "{foldername}.zip" asset on that release - currently just "holo_test_data_01"
-    (see https://github.com/SINTEF/pyopia/releases/tag/sample-data). This used to
-    fetch from a Google Drive folder via `gdown`, which was a source of
+    (see https://github.com/SINTEF/pyopia/releases/tag/sample-data_v2.0.0). This used
+    to fetch from a Google Drive folder via `gdown`, which was a source of
     flaky/rate-limited downloads in CI (#421). GitHub release assets are the
     officially-recommended place for large files associated with a repo (no size or
     bandwidth limit, unlike committing them into git history) - see the discussion on
@@ -184,7 +184,7 @@ def get_folder_from_holo_repository(foldername="holo_test_data_01", existsok=Fal
     Parameters
     ----------
     foldername : string
-        name of a folder hosted as "{foldername}.zip" on the "sample-data" release
+        name of a folder hosted as "{foldername}.zip" on the "sample-data_v2.0.0" release
     existsok : (bool, optional)
         if True, then don't download if the specified folder already exists, defaults to False
 
@@ -197,7 +197,7 @@ def get_folder_from_holo_repository(foldername="holo_test_data_01", existsok=Fal
         logger.info(foldername + " already exists. Skipping download.")
         return foldername
 
-    url = f"https://github.com/SINTEF/pyopia/releases/download/sample-data/{foldername}.zip"
+    url = f"https://github.com/SINTEF/pyopia/releases/download/sample-data_v2.0.0/{foldername}.zip"
     zip_path = f"{foldername}.zip"
     urllib.request.urlretrieve(url, zip_path, reporthook=_make_progress_hook(zip_path))
     with zipfile.ZipFile(zip_path, "r") as zipit:

--- a/pyopia/exampledata.py
+++ b/pyopia/exampledata.py
@@ -1,7 +1,6 @@
 import urllib.request
 import zipfile
 import os
-import gdown
 from pathlib import Path
 
 import logging
@@ -170,32 +169,38 @@ def get_example_hologram_and_background(download_directory="./"):
 
 
 def get_folder_from_holo_repository(foldername="holo_test_data_01", existsok=False):
-    """Downloads a specified folder from the holo testing repository into the working dir. if it doesn't already exist
+    """Downloads and unzips a folder of holo test images from the "sample-data" GitHub
+    release into the working dir, if it doesn't already exist.
 
-    only works for known folders that are on the GoogleDrive repository
-    by default will download a known-good folder. Additional elif statements can be added to implement additional folders.
+    Only works for folder names that have actually been uploaded as a
+    "{foldername}.zip" asset on that release - currently just "holo_test_data_01"
+    (see https://github.com/SINTEF/pyopia/releases/tag/sample-data). This used to
+    fetch from a Google Drive folder via `gdown`, which was a source of
+    flaky/rate-limited downloads in CI (#421). GitHub release assets are the
+    officially-recommended place for large files associated with a repo (no size or
+    bandwidth limit, unlike committing them into git history) - see the discussion on
+    #421 for why this isn't pysilcam's existing blob storage instead.
 
     Parameters
     ----------
     foldername : string
-        known filename on the blob
+        name of a folder hosted as "{foldername}.zip" on the "sample-data" release
     existsok : (bool, optional)
         if True, then don't download if the specified folder already exists, defaults to False
 
+    Returns
+    -------
+    string
+        foldername, the directory that was downloaded and unzipped (or already existed)
     """
-    if foldername == "holo_test_data_01":
-        url = "https://drive.google.com/drive/folders/1yNatOaKdWwYQp-5WVEDItoibr-k0lGsP?usp=share_link"
-
-    elif foldername == "holo_test_data_02":
-        url = "https://drive.google.com/drive/folders/1E5iNSyfeKcVMLVe4PNEwF2Q2mo3WVjF5?usp=share_link"
-
-    else:
-        foldername == "holo_test_data_01"
-        url = "https://drive.google.com/drive/folders/1yNatOaKdWwYQp-5WVEDItoibr-k0lGsP?usp=share_link"
-
     if os.path.exists(foldername) and existsok:
         logger.info(foldername + " already exists. Skipping download.")
         return foldername
 
-    gdown.download_folder(url, quiet=True, use_cookies=False)
+    url = f"https://github.com/SINTEF/pyopia/releases/download/sample-data/{foldername}.zip"
+    zip_path = f"{foldername}.zip"
+    urllib.request.urlretrieve(url, zip_path, reporthook=_make_progress_hook(zip_path))
+    with zipfile.ZipFile(zip_path, "r") as zipit:
+        zipit.extractall(".")
+    os.remove(zip_path)
     return foldername

--- a/pyopia/exampledata.py
+++ b/pyopia/exampledata.py
@@ -9,6 +9,26 @@ import logging
 logger = logging.getLogger()
 
 
+def _make_progress_hook(label):
+    """Build a `urllib.request.urlretrieve` reporthook that logs download progress.
+
+    Logs at 10%-increments (never more often than that, to avoid spamming logs with
+    one line per block) rather than every callback.
+    """
+    last_logged = -1
+
+    def _hook(block_count, block_size, total_size):
+        nonlocal last_logged
+        if total_size <= 0:
+            return
+        percent = min(100, block_count * block_size * 100 // total_size)
+        if percent >= last_logged + 10 or percent == 100:
+            logger.info(f"Downloading {label}... {percent}%")
+            last_logged = percent
+
+    return _hook
+
+
 def get_classifier_database_from_pysilcam_blob(download_directory="./"):
     """Downloads and unzips the silcam_database of labelled example images from pysilcam.blob
     into the working dir. if it doesn't already exist
@@ -30,7 +50,9 @@ def get_classifier_database_from_pysilcam_blob(download_directory="./"):
     os.makedirs(download_directory, exist_ok=False)
     url = "https://pysilcam.blob.core.windows.net/test-data/silcam_database.zip"
     logger.info("Downloading....")
-    urllib.request.urlretrieve(url, download_directory + "/silcam_database.zip")
+    urllib.request.urlretrieve(
+        url, download_directory + "/silcam_database.zip", reporthook=_make_progress_hook("silcam_database.zip")
+    )
     logger.info("Unzipping....")
     with zipfile.ZipFile(
         os.path.join(download_directory, "silcam_database.zip"), "r"
@@ -63,7 +85,9 @@ def get_file_from_pysilcam_blob(filename, download_directory="./"):
     if os.path.exists(os.path.join(download_directory, filename)):
         return filename
     url = "https://pysilcam.blob.core.windows.net/test-data/" + filename
-    urllib.request.urlretrieve(url, os.path.join(download_directory, filename))
+    urllib.request.urlretrieve(
+        url, os.path.join(download_directory, filename), reporthook=_make_progress_hook(filename)
+    )
     return download_directory
 
 
@@ -112,7 +136,7 @@ def get_example_model(download_directory="./"):
     )
     if not model_path.exists():
         logger.info("Downloading example model...")
-        urllib.request.urlretrieve(model_url, model_path)
+        urllib.request.urlretrieve(model_url, model_path, reporthook=_make_progress_hook("classifier model"))
     return str(model_path)
 
 

--- a/pyopia/tests/test_cli.py
+++ b/pyopia/tests/test_cli.py
@@ -309,3 +309,25 @@ def test_export_to_ecotaxa_creates_bundle_zip(silcam_cli_merged_stats, tmp_path)
         names = bundle.namelist()
         assert 'ecotaxa_particle_statistics.tsv' in names
         assert sum(name.endswith('.png') for name in names) == 1740
+
+
+@pytest.mark.slow
+def test_summary_stats_json_output(silcam_cli_merged_stats, tmp_path):
+    result = invoke_in(tmp_path, ['summary-stats', str(silcam_cli_merged_stats), '--json-output'])
+
+    assert result.exit_code == 0, result.output
+    summary = json.loads(result.output)
+
+    assert summary['particle_count'] == 1740
+    assert summary['images_with_particles'] == 2
+    assert summary['d50_microns'] > 0
+    assert len(summary['dias']) == len(summary['number_distribution']) == 52
+
+
+@pytest.mark.slow
+def test_summary_stats_human_readable_output(silcam_cli_merged_stats, tmp_path):
+    result = invoke_in(tmp_path, ['summary-stats', str(silcam_cli_merged_stats)])
+
+    assert result.exit_code == 0, result.output
+    assert 'Particle count: 1740' in result.output
+    assert 'Images with particles: 2' in result.output

--- a/pyopia/tests/test_cli.py
+++ b/pyopia/tests/test_cli.py
@@ -145,15 +145,15 @@ def test_init_project_refuses_to_overwrite_existing_folder(tmp_path):
 
 
 @pytest.mark.slow
-@pytest.mark.flaky(reruns=2, reruns_delay=10)
 def test_init_project_with_example_data_downloads_real_holo_images(tmp_path):
     '''Regression test for #434: --instrument holo previously always got silcam example
     data regardless (and raw_files was hardcoded to *.silc for every instrument, so a
     generated holo config could never have matched real holo files anyway).
 
-    Retries on failure: this downloads via gdown/Google Drive
-    (get_folder_from_holo_repository), the same flaky path #421 already documents -
-    confirmed hitting that exact rate-limiting during development of this test.
+    get_folder_from_holo_repository previously downloaded via gdown/Google Drive, the
+    flaky path #421 documents (confirmed hitting that exact rate-limiting during
+    initial development of this test) - now downloads from the same blob storage
+    everything else in exampledata.py uses, so no retry treatment needed here.
     '''
     result = invoke_in(tmp_path, [
         'init-project', 'holoproj', '--instrument', 'holo', '--example-data'

--- a/pyopia/tests/test_cli.py
+++ b/pyopia/tests/test_cli.py
@@ -139,7 +139,7 @@ def test_init_project_refuses_to_overwrite_existing_folder(tmp_path):
 
     result = invoke_in(tmp_path, ['init-project', 'myproj'])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert 'ERROR' in result.output
     assert not (existing_project / 'config.toml').exists()
 
@@ -182,6 +182,25 @@ def test_process_produces_real_particle_stats_and_roi_export(silcam_cli_project)
 
     roi_files = list(silcam_cli_project['roi_folder'].glob('*.h5'))
     assert len(roi_files) == len(silcam_cli_project['stats_files']) == 2
+
+
+@pytest.mark.slow
+def test_process_writes_progress_file_when_requested(tmp_path, silcam_cli_project):
+    '''Regression test for #423: re-runs the real silcam_cli_project config (reusing its
+    already-downloaded data rather than a fresh download) with --progress-file, and
+    checks the final written JSON reflects both images having been processed.
+    '''
+    progress_file = tmp_path / 'progress.json'
+
+    result = invoke_in(silcam_cli_project['project_dir'], [
+        'process', str(silcam_cli_project['config_filename']), '--progress-file', str(progress_file)
+    ])
+
+    assert result.exit_code == 0, result.output
+    assert progress_file.is_file()
+
+    progress = json.loads(progress_file.read_text())
+    assert progress == {'processed': 2, 'total': 2}
 
 
 def test_process_realtime_requires_an_output_step(tmp_path):

--- a/pyopia/tests/test_cli.py
+++ b/pyopia/tests/test_cli.py
@@ -295,6 +295,19 @@ def test_make_montage_creates_real_montage_image(silcam_cli_merged_stats, tmp_pa
 
 
 @pytest.mark.slow
+def test_make_montage_scaled_creates_real_montage_image(silcam_cli_merged_stats, tmp_path):
+    montage_path = tmp_path / 'montage_scaled.png'
+
+    result = invoke_in(tmp_path, [
+        'make-montage-scaled', str(silcam_cli_merged_stats), '--output-filename', str(montage_path)
+    ])
+
+    assert result.exit_code == 0, result.output
+    assert montage_path.is_file()
+    assert montage_path.stat().st_size > 0
+
+
+@pytest.mark.slow
 def test_export_to_ecotaxa_creates_bundle_zip(silcam_cli_merged_stats, tmp_path):
     export_path = tmp_path / 'ecotaxa_export.zip'
 

--- a/pyopia/tests/test_cli.py
+++ b/pyopia/tests/test_cli.py
@@ -144,6 +144,31 @@ def test_init_project_refuses_to_overwrite_existing_folder(tmp_path):
     assert not (existing_project / 'config.toml').exists()
 
 
+@pytest.mark.slow
+@pytest.mark.flaky(reruns=2, reruns_delay=10)
+def test_init_project_with_example_data_downloads_real_holo_images(tmp_path):
+    '''Regression test for #434: --instrument holo previously always got silcam example
+    data regardless (and raw_files was hardcoded to *.silc for every instrument, so a
+    generated holo config could never have matched real holo files anyway).
+
+    Retries on failure: this downloads via gdown/Google Drive
+    (get_folder_from_holo_repository), the same flaky path #421 already documents -
+    confirmed hitting that exact rate-limiting during development of this test.
+    '''
+    result = invoke_in(tmp_path, [
+        'init-project', 'holoproj', '--instrument', 'holo', '--example-data'
+    ])
+
+    assert result.exit_code == 0, result.output
+
+    proj_folder = tmp_path / 'holoproj'
+    config = toml.load(proj_folder / 'config.toml')
+    assert config['general']['raw_files'] == 'images/holo_test_data_01/*.pgm'
+
+    matched_files = list(proj_folder.glob('images/holo_test_data_01/*.pgm'))
+    assert len(matched_files) > 0
+
+
 def test_check_chunks_rejects_less_than_one_chunk():
     with pytest.raises(RuntimeError, match='at least 1 chunk'):
         pyopia.cli.check_chunks(0, {'steps': {'output': {}}})

--- a/pyopia/tests/test_exampledata.py
+++ b/pyopia/tests/test_exampledata.py
@@ -1,0 +1,37 @@
+import logging
+
+import pyopia.exampledata
+
+
+def test_progress_hook_logs_at_ten_percent_increments(caplog):
+    hook = pyopia.exampledata._make_progress_hook("test.zip")
+    block_size = 1024
+    total_size = 10 * block_size  # 10 blocks = 10% per block
+
+    with caplog.at_level(logging.INFO, logger=pyopia.exampledata.logger.name):
+        for block_count in range(1, 11):
+            hook(block_count, block_size, total_size)
+
+    percents_logged = [int(r.message.rsplit(' ', 1)[-1].rstrip('%')) for r in caplog.records]
+    assert percents_logged == [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+
+
+def test_progress_hook_does_not_log_between_increments(caplog):
+    hook = pyopia.exampledata._make_progress_hook("test.zip")
+    block_size = 1
+    total_size = 1000  # each block is 0.1%, well under the 10% threshold
+
+    with caplog.at_level(logging.INFO, logger=pyopia.exampledata.logger.name):
+        for block_count in range(1, 50):
+            hook(block_count, block_size, total_size)
+
+    assert len(caplog.records) == 0
+
+
+def test_progress_hook_ignores_unknown_total_size(caplog):
+    hook = pyopia.exampledata._make_progress_hook("test.zip")
+
+    with caplog.at_level(logging.INFO, logger=pyopia.exampledata.logger.name):
+        hook(1, 1024, -1)
+
+    assert len(caplog.records) == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "jupyter-book>=0.15.1,<0.16",
     "ipykernel>=6.19.4",
     "urllib3>=2.5.0,<3",
-    "gdown>=5.2.2,<7",
     "cmocean>=3.0.3,<4",
     "toml>=0.10.2,<0.11",
     "xarray>=2023.12.0,<2024",


### PR DESCRIPTION
Staging branch for pyopia-gui fixes.

Not for merging as one PR - each fix lands in `main` via its own PR (`Closes #N`). See `PYOPIA_GUI_SUPPORT.md` on the branch for the branch's own purpose/scope note.

Each bullet below links to the specific commit that makes that change, so you can review them individually rather than as one combined diff.

## CLI improvements
- Closes #423: init-project now exits 1 on an existing target folder; process() adds --progress-file for machine-readable progress polling and routes its stage banners/completion message through the same logger as everything else (so they respect general.log_file); fixes a docstring bug in process() and generate_config(); adds Windows/PowerShell Docker guidance to the README. ([`8c719fd`](https://github.com/SINTEF/pyopia/pull/435/commits/8c719fd98757e5d25b1e3b4f73a1827943de65af))
- Closes #427: adds a `summary-stats` command (particle count, d50, size distribution from a `-STATS.nc` file, with `--json-output` for machine-readable output), field names matching pyopia-gui's vendored `StatsSummary` shape for an easy future migration. ([`90b639a`](https://github.com/SINTEF/pyopia/pull/435/commits/90b639a88bd7449b8b6fc9b218f6d99208cb0e9c))
- Adds a `make-montage-scaled` command, wiring `pyopia.statistics.make_montage_scaled` (#407) into the CLI alongside the existing `make-montage`. ([`8b2b37a`](https://github.com/SINTEF/pyopia/pull/435/commits/8b2b37a82e03bc625afe987e3a98a08ec77060c2))

## Example data
- Closes #434 (holo only - uvp split to #436): `init-project --example-data --instrument holo` now downloads real holograms and generates a config that actually matches them - two real bugs fixed along the way (raw_files was hardcoded to `*.silc` for every instrument; example_data forced instrument back to silcam regardless of what was requested). ([`cc705d7`](https://github.com/SINTEF/pyopia/pull/435/commits/cc705d762744ce7097084e39dd9c5e8c7bf332fb))
- Closes #426: logs download progress at 10%-increments for the example-data fetches in `exampledata.py`, previously silent enough to look like a hang on a slow connection. ([`30fdccc`](https://github.com/SINTEF/pyopia/pull/435/commits/30fdcccd3daacd51ec71282d290d25e6e1dc07db))
- Closes #421 (code ready, blocked - see issue for details): migrates holo test-data download off `gdown`/Google Drive (repeatedly rate-limited in CI) onto a GitHub release, removing the `gdown` dependency entirely. Needs someone with tag-creation rights to actually create the release - not something I can do from here. ([`a9050a8`](https://github.com/SINTEF/pyopia/pull/435/commits/a9050a8945059b2c09cf4bec3e946a33d2e2633c))

## Test plan
- [x] `flake8 pyopia` clean
- [x] `uv run pytest -m "not slow"` passing
- [ ] CI green - blocked on #421 (see above) until the `sample-data` release exists